### PR TITLE
remove unnecessary seeds checks

### DIFF
--- a/clients/js/src/generated/instructions/sellNftTokenPool.ts
+++ b/clients/js/src/generated/instructions/sellNftTokenPool.ts
@@ -331,7 +331,7 @@ export type SellNftTokenPoolAsyncInput<
   ownerTokenRecord?: Address<TAccountOwnerTokenRecord>;
   /** The Token Metadata seller/source token record account of the NFT. */
   sellerTokenRecord?: Address<TAccountSellerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -754,7 +754,7 @@ export type SellNftTokenPoolInput<
   ownerTokenRecord?: Address<TAccountOwnerTokenRecord>;
   /** The Token Metadata seller/source token record account of the NFT. */
   sellerTokenRecord?: Address<TAccountSellerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -1116,7 +1116,7 @@ export type ParsedSellNftTokenPoolInstruction<
     ownerTokenRecord?: TAccountMetas[16] | undefined;
     /** The Token Metadata seller/source token record account of the NFT. */
     sellerTokenRecord?: TAccountMetas[17] | undefined;
-    /** The Token Metadata pool temporary token record account of the NFT. */
+    /** The Token Metadata token record for the pool. */
     poolTokenRecord?: TAccountMetas[18] | undefined;
     /** The Token Metadata program account. */
     tokenMetadataProgram?: TAccountMetas[19] | undefined;

--- a/clients/js/src/generated/instructions/sellNftTradePool.ts
+++ b/clients/js/src/generated/instructions/sellNftTradePool.ts
@@ -312,7 +312,7 @@ export type SellNftTradePoolAsyncInput<
   edition?: Address<TAccountEdition>;
   /** The Token Metadata seller/source token record account of the NFT. */
   sellerTokenRecord?: Address<TAccountSellerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -706,7 +706,7 @@ export type SellNftTradePoolInput<
   edition: Address<TAccountEdition>;
   /** The Token Metadata seller/source token record account of the NFT. */
   sellerTokenRecord?: Address<TAccountSellerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -1041,7 +1041,7 @@ export type ParsedSellNftTradePoolInstruction<
     edition: TAccountMetas[14];
     /** The Token Metadata seller/source token record account of the NFT. */
     sellerTokenRecord?: TAccountMetas[15] | undefined;
-    /** The Token Metadata pool temporary token record account of the NFT. */
+    /** The Token Metadata token record for the pool. */
     poolTokenRecord?: TAccountMetas[16] | undefined;
     /** The Token Metadata program account. */
     tokenMetadataProgram?: TAccountMetas[17] | undefined;

--- a/clients/js/src/generated/instructions/withdrawNft.ts
+++ b/clients/js/src/generated/instructions/withdrawNft.ts
@@ -223,10 +223,11 @@ export type WithdrawNftAsyncInput<
   tokenProgram?: Address<TAccountTokenProgram>;
   associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
   systemProgram?: Address<TAccountSystemProgram>;
+  /** The Token Metadata metadata account of the NFT. */
   metadata?: Address<TAccountMetadata>;
   edition?: Address<TAccountEdition>;
   ownerTokenRecord?: Address<TAccountOwnerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -498,10 +499,11 @@ export type WithdrawNftInput<
   tokenProgram?: Address<TAccountTokenProgram>;
   associatedTokenProgram?: Address<TAccountAssociatedTokenProgram>;
   systemProgram?: Address<TAccountSystemProgram>;
+  /** The Token Metadata metadata account of the NFT. */
   metadata: Address<TAccountMetadata>;
   edition: Address<TAccountEdition>;
   ownerTokenRecord?: Address<TAccountOwnerTokenRecord>;
-  /** The Token Metadata pool temporary token record account of the NFT. */
+  /** The Token Metadata token record for the pool. */
   poolTokenRecord?: Address<TAccountPoolTokenRecord>;
   /** The Token Metadata program account. */
   tokenMetadataProgram?: Address<TAccountTokenMetadataProgram>;
@@ -728,10 +730,11 @@ export type ParsedWithdrawNftInstruction<
     tokenProgram: TAccountMetas[6];
     associatedTokenProgram: TAccountMetas[7];
     systemProgram: TAccountMetas[8];
+    /** The Token Metadata metadata account of the NFT. */
     metadata: TAccountMetas[9];
     edition: TAccountMetas[10];
     ownerTokenRecord?: TAccountMetas[11] | undefined;
-    /** The Token Metadata pool temporary token record account of the NFT. */
+    /** The Token Metadata token record for the pool. */
     poolTokenRecord?: TAccountMetas[12] | undefined;
     /** The Token Metadata program account. */
     tokenMetadataProgram?: TAccountMetas[13] | undefined;

--- a/clients/rust/src/generated/instructions/sell_nft_token_pool.rs
+++ b/clients/rust/src/generated/instructions/sell_nft_token_pool.rs
@@ -51,7 +51,7 @@ pub struct SellNftTokenPool {
     pub owner_token_record: Option<solana_program::pubkey::Pubkey>,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<solana_program::pubkey::Pubkey>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<solana_program::pubkey::Pubkey>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<solana_program::pubkey::Pubkey>,
@@ -519,7 +519,7 @@ impl SellNftTokenPoolBuilder {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,
@@ -745,7 +745,7 @@ pub struct SellNftTokenPoolCpiAccounts<'a, 'b> {
     pub owner_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -814,7 +814,7 @@ pub struct SellNftTokenPoolCpi<'a, 'b> {
     pub owner_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -1434,7 +1434,7 @@ impl<'a, 'b> SellNftTokenPoolCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,

--- a/clients/rust/src/generated/instructions/sell_nft_trade_pool.rs
+++ b/clients/rust/src/generated/instructions/sell_nft_trade_pool.rs
@@ -47,7 +47,7 @@ pub struct SellNftTradePool {
     pub edition: solana_program::pubkey::Pubkey,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<solana_program::pubkey::Pubkey>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<solana_program::pubkey::Pubkey>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<solana_program::pubkey::Pubkey>,
@@ -475,7 +475,7 @@ impl SellNftTradePoolBuilder {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,
@@ -695,7 +695,7 @@ pub struct SellNftTradePoolCpiAccounts<'a, 'b> {
     pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -760,7 +760,7 @@ pub struct SellNftTradePoolCpi<'a, 'b> {
     pub edition: &'b solana_program::account_info::AccountInfo<'a>,
     /// The Token Metadata seller/source token record account of the NFT.
     pub seller_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -1331,7 +1331,7 @@ impl<'a, 'b> SellNftTradePoolCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,

--- a/clients/rust/src/generated/instructions/withdraw_nft.rs
+++ b/clients/rust/src/generated/instructions/withdraw_nft.rs
@@ -29,13 +29,13 @@ pub struct WithdrawNft {
     pub associated_token_program: solana_program::pubkey::Pubkey,
 
     pub system_program: solana_program::pubkey::Pubkey,
-
+    /// The Token Metadata metadata account of the NFT.
     pub metadata: solana_program::pubkey::Pubkey,
 
     pub edition: solana_program::pubkey::Pubkey,
 
     pub owner_token_record: Option<solana_program::pubkey::Pubkey>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<solana_program::pubkey::Pubkey>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<solana_program::pubkey::Pubkey>,
@@ -303,6 +303,7 @@ impl WithdrawNftBuilder {
         self.system_program = Some(system_program);
         self
     }
+    /// The Token Metadata metadata account of the NFT.
     #[inline(always)]
     pub fn metadata(&mut self, metadata: solana_program::pubkey::Pubkey) -> &mut Self {
         self.metadata = Some(metadata);
@@ -323,7 +324,7 @@ impl WithdrawNftBuilder {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,
@@ -451,13 +452,13 @@ pub struct WithdrawNftCpiAccounts<'a, 'b> {
     pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
-
+    /// The Token Metadata metadata account of the NFT.
     pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub edition: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub owner_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -491,13 +492,13 @@ pub struct WithdrawNftCpi<'a, 'b> {
     pub associated_token_program: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub system_program: &'b solana_program::account_info::AccountInfo<'a>,
-
+    /// The Token Metadata metadata account of the NFT.
     pub metadata: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub edition: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub owner_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     pub pool_token_record: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The Token Metadata program account.
     pub token_metadata_program: Option<&'b solana_program::account_info::AccountInfo<'a>>,
@@ -860,6 +861,7 @@ impl<'a, 'b> WithdrawNftCpiBuilder<'a, 'b> {
         self.instruction.system_program = Some(system_program);
         self
     }
+    /// The Token Metadata metadata account of the NFT.
     #[inline(always)]
     pub fn metadata(
         &mut self,
@@ -886,7 +888,7 @@ impl<'a, 'b> WithdrawNftCpiBuilder<'a, 'b> {
         self
     }
     /// `[optional account]`
-    /// The Token Metadata pool temporary token record account of the NFT.
+    /// The Token Metadata token record for the pool.
     #[inline(always)]
     pub fn pool_token_record(
         &mut self,

--- a/program/idl/amm_program.json
+++ b/program/idl/amm_program.json
@@ -450,7 +450,10 @@
         {
           "name": "metadata",
           "isMut": true,
-          "isSigner": false
+          "isSigner": false,
+          "docs": [
+            "The Token Metadata metadata account of the NFT."
+          ]
         },
         {
           "name": "edition",
@@ -469,7 +472,7 @@
           "isSigner": false,
           "isOptional": true,
           "docs": [
-            "The Token Metadata pool temporary token record account of the NFT."
+            "The Token Metadata token record for the pool."
           ]
         },
         {
@@ -954,7 +957,7 @@
           "isSigner": false,
           "isOptional": true,
           "docs": [
-            "The Token Metadata pool temporary token record account of the NFT."
+            "The Token Metadata token record for the pool."
           ]
         },
         {
@@ -1187,7 +1190,7 @@
           "isSigner": false,
           "isOptional": true,
           "docs": [
-            "The Token Metadata pool temporary token record account of the NFT."
+            "The Token Metadata token record for the pool."
           ]
         },
         {

--- a/program/src/instructions/buy_nft.rs
+++ b/program/src/instructions/buy_nft.rs
@@ -91,14 +91,14 @@ pub struct BuyNft<'info> {
     pub mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// The Token Metadata metadata account of the NFT.
-    ///  CHECK: seeds and ownership are checked in assert_decode_metadata.
+    /// CHECK: ownership, structure and mint are checked in assert_decode_metadata.
     #[account(mut)]
     pub metadata: UncheckedAccount<'info>,
 
     /// The NFT deposit receipt account, which tracks an NFT to the pool it was deposited to.
     #[account(
         mut,
-        seeds=[
+        seeds = [
             b"nft_receipt".as_ref(),
             mint.key().as_ref(),
             pool.key().as_ref(),

--- a/program/src/instructions/deposit_nft.rs
+++ b/program/src/instructions/deposit_nft.rs
@@ -87,7 +87,7 @@ pub struct DepositNft<'info> {
     pub system_program: Program<'info, System>,
 
     /// The Token Metadata metadata account of the NFT.
-    /// CHECK: assert_decode_metadata checks seeds, owner, and key
+    /// CHECK: ownership, structure and mint are checked in assert_decode_metadata.
     pub metadata: UncheckedAccount<'info>,
 
     /// CHECK: seeds below + assert_decode_mint_proof

--- a/program/src/instructions/sell_nft_token_pool.rs
+++ b/program/src/instructions/sell_nft_token_pool.rs
@@ -111,7 +111,7 @@ pub struct SellNftTokenPool<'info> {
     pub mint: Box<InterfaceAccount<'info, Mint>>,
 
     /// The Token Metadata metadata account of the NFT.
-    ///  CHECK: seeds and ownership are checked in assert_decode_metadata.
+    /// CHECK: ownership, structure and mint are checked in assert_decode_metadata.
     #[account(mut)]
     pub metadata: UncheckedAccount<'info>,
 
@@ -138,19 +138,9 @@ pub struct SellNftTokenPool<'info> {
     #[account(mut)]
     pub seller_token_record: Option<UncheckedAccount<'info>>,
 
-    /// The Token Metadata pool temporary token record account of the NFT.
-    /// CHECK: seeds checked here
-    #[account(mut,
-            seeds=[
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.0,
-            mpl_token_metadata::ID.as_ref(),
-            mint.key().as_ref(),
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.1,
-            pool_ata.key().as_ref()
-        ],
-        seeds::program = mpl_token_metadata::ID,
-        bump
-    )]
+    /// The Token Metadata token record for the pool.
+    /// CHECK: seeds checked on Token Metadata CPI
+    #[account(mut)]
     pub pool_token_record: Option<UncheckedAccount<'info>>,
 
     // Todo: add ProgNftShared back in, if possible

--- a/program/src/instructions/sell_nft_trade_pool.rs
+++ b/program/src/instructions/sell_nft_trade_pool.rs
@@ -98,7 +98,7 @@ pub struct SellNftTradePool<'info> {
     pub pool_ata: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// The Token Metadata metadata account of the NFT.
-    ///  CHECK: seeds and ownership are checked in assert_decode_metadata.
+    /// CHECK: ownership, structure and mint are checked in assert_decode_metadata.
     #[account(mut)]
     pub metadata: UncheckedAccount<'info>,
 
@@ -130,19 +130,9 @@ pub struct SellNftTradePool<'info> {
     #[account(mut)]
     pub seller_token_record: Option<UncheckedAccount<'info>>,
 
-    /// The Token Metadata pool temporary token record account of the NFT.
-    /// CHECK: seeds checked here
-    #[account(mut,
-            seeds=[
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.0,
-            mpl_token_metadata::ID.as_ref(),
-            mint.key().as_ref(),
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.1,
-            pool_ata.key().as_ref()
-        ],
-        seeds::program = mpl_token_metadata::ID,
-        bump
-    )]
+    /// The Token Metadata token record for the pool.
+    /// CHECK: seeds checked on Token Metadata CPI
+    #[account(mut)]
     pub pool_token_record: Option<UncheckedAccount<'info>>,
 
     // Todo: add ProgNftShared back in, if possible

--- a/program/src/instructions/withdraw_nft.rs
+++ b/program/src/instructions/withdraw_nft.rs
@@ -78,19 +78,9 @@ pub struct WithdrawNft<'info> {
     pub system_program: Program<'info, System>,
 
     // --------------------------------------- pNft
-
-    //can't deserialize directly coz Anchor traits not implemented
-    /// CHECK: seeds below
-    #[account(
-        mut,
-        seeds=[
-            mpl_token_metadata::accounts::Metadata::PREFIX,
-            mpl_token_metadata::ID.as_ref(),
-            mint.key().as_ref(),
-        ],
-        seeds::program = mpl_token_metadata::ID,
-        bump
-    )]
+    /// The Token Metadata metadata account of the NFT.
+    /// CHECK: ownership, structure and mint are checked in assert_decode_metadata.
+    #[account(mut)]
     pub metadata: UncheckedAccount<'info>,
 
     //note that MASTER EDITION and EDITION share the same seeds, and so it's valid to check them here
@@ -101,19 +91,9 @@ pub struct WithdrawNft<'info> {
     #[account(mut)]
     pub owner_token_record: Option<UncheckedAccount<'info>>,
 
-    /// The Token Metadata pool temporary token record account of the NFT.
-    /// CHECK: seeds checked here
-    #[account(mut,
-            seeds=[
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.0,
-            mpl_token_metadata::ID.as_ref(),
-            mint.key().as_ref(),
-            mpl_token_metadata::accounts::TokenRecord::PREFIX.1,
-            pool_ata.key().as_ref()
-        ],
-        seeds::program = mpl_token_metadata::ID,
-        bump
-    )]
+    /// The Token Metadata token record for the pool.
+    /// CHECK: seeds checked on Token Metadata CPI
+    #[account(mut)]
     pub pool_token_record: Option<UncheckedAccount<'info>>,
 
     // Todo: add ProgNftShared back in, if possible


### PR DESCRIPTION
Removes unnecessary seeds checks on Token Metadata accounts.

Metadata account ownership and relationship to a specific mint is checked in `assert_decode_metadata` and `TokenRecord` accounts are checked by the Token Metadata program itself.