### PR TITLE
custom escrowProgram resolver

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/amm",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Version 2 of the Tensor AMM program.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",
@@ -39,7 +39,7 @@
   "dependencies": {
     "@solana-program/token": "^0.2.0",
     "@solana/web3.js": "2.0.0-preview.3",
-    "@tensor-foundation/resolvers": "file:../../../toolkit/resolvers"
+    "@tensor-foundation/resolvers": "^0.2.4"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@solana-program/token": "^0.2.0",
     "@solana/web3.js": "2.0.0-preview.3",
-    "@tensor-foundation/resolvers": "^0.2.3"
+    "@tensor-foundation/resolvers": "file:../../../toolkit/resolvers"
   },
   "devDependencies": {
     "@ava/typescript": "^4.1.0",

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tensor-foundation/resolvers':
-        specifier: file:../../../toolkit/resolvers
-        version: file:../../../toolkit/resolvers(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+        specifier: ^0.2.4
+        version: 0.2.4(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
     devDependencies:
       '@ava/typescript':
         specifier: ^4.1.0
@@ -1752,8 +1752,8 @@ packages:
   '@tensor-foundation/mpl-token-metadata@0.5.0':
     resolution: {integrity: sha512-6kiLf5myc4qDiobuKHZLj1sBnfaaKfdIZeZbnucqIZuCO8P058VAyjzVEGpm2aw49l1Uxhuk0U+Qn3R1gf6Eww==}
 
-  '@tensor-foundation/resolvers@file:../../../toolkit/resolvers':
-    resolution: {directory: ../../../toolkit/resolvers, type: directory}
+  '@tensor-foundation/resolvers@0.2.4':
+    resolution: {integrity: sha512-HsUUqDXVIKC2CGKD1PNnHiQ1XvZcZfRNdllcGOlOlcc/uswC9OlMwa2WeMaN8spu+lHpC7i+Kn6qyz5IWY4fcA==}
     peerDependencies:
       '@solana/web3.js': 2.0.0-preview.3
 
@@ -7455,7 +7455,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@tensor-foundation/resolvers@file:../../../toolkit/resolvers(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
+  '@tensor-foundation/resolvers@0.2.4(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/web3.js': 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
 

--- a/clients/js/pnpm-lock.yaml
+++ b/clients/js/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 2.0.0-preview.3
         version: 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       '@tensor-foundation/resolvers':
-        specifier: ^0.2.3
-        version: 0.2.3(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
+        specifier: file:../../../toolkit/resolvers
+        version: file:../../../toolkit/resolvers(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))
     devDependencies:
       '@ava/typescript':
         specifier: ^4.1.0
@@ -1752,8 +1752,8 @@ packages:
   '@tensor-foundation/mpl-token-metadata@0.5.0':
     resolution: {integrity: sha512-6kiLf5myc4qDiobuKHZLj1sBnfaaKfdIZeZbnucqIZuCO8P058VAyjzVEGpm2aw49l1Uxhuk0U+Qn3R1gf6Eww==}
 
-  '@tensor-foundation/resolvers@0.2.3':
-    resolution: {integrity: sha512-t60CczEisiG9MVm3qpoFRT6JVppOw/JDRLJYES2A4HWQmPo//VvMCrt+DTjER0Jrloz9UCSIw7IN4rCm0YUymQ==}
+  '@tensor-foundation/resolvers@file:../../../toolkit/resolvers':
+    resolution: {directory: ../../../toolkit/resolvers, type: directory}
     peerDependencies:
       '@solana/web3.js': 2.0.0-preview.3
 
@@ -7455,7 +7455,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@tensor-foundation/resolvers@0.2.3(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
+  '@tensor-foundation/resolvers@file:../../../toolkit/resolvers(@solana/web3.js@2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/web3.js': 2.0.0-preview.3(fastestsmallesttextencoderdecoder@1.0.22)(ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))
 

--- a/clients/js/src/generated/instructions/buyNft.ts
+++ b/clients/js/src/generated/instructions/buyNft.ts
@@ -45,6 +45,7 @@ import {
   TokenStandard,
   resolveAuthorizationRulesProgramFromTokenStandard,
   resolveEditionFromTokenStandard,
+  resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolvePoolAta,
   resolvePoolTokenRecordFromTokenStandard,
@@ -544,6 +545,12 @@ export async function getBuyNftInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -971,6 +978,12 @@ export function getBuyNftInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/buyNftCore.ts
+++ b/clients/js/src/generated/instructions/buyNftCore.ts
@@ -34,6 +34,7 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
+import { resolveEscrowProgramFromSharedEscrow } from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool } from '../../hooked';
 import { findAssetDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
@@ -366,6 +367,12 @@ export async function getBuyNftCoreInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -613,6 +620,9 @@ export function getBuyNftCoreInstruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -620,6 +630,12 @@ export function getBuyNftCoreInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/buyNftT22.ts
+++ b/clients/js/src/generated/instructions/buyNftT22.ts
@@ -34,7 +34,10 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
-import { resolvePoolAta } from '@tensor-foundation/resolvers';
+import {
+  resolveEscrowProgramFromSharedEscrow,
+  resolvePoolAta,
+} from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool, resolveTakerAta } from '../../hooked';
 import { findNftDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
@@ -396,6 +399,12 @@ export async function getBuyNftT22InstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -689,6 +698,9 @@ export function getBuyNftT22Instruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -696,6 +708,12 @@ export function getBuyNftT22Instruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTokenPool.ts
+++ b/clients/js/src/generated/instructions/sellNftTokenPool.ts
@@ -45,6 +45,7 @@ import {
   TokenStandard,
   resolveAuthorizationRulesProgramFromTokenStandard,
   resolveEditionFromTokenStandard,
+  resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolveOwnerAta,
   resolveOwnerTokenRecordFromTokenStandard,
@@ -560,6 +561,12 @@ export async function getSellNftTokenPoolInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -1005,6 +1012,12 @@ export function getSellNftTokenPoolInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTokenPoolCore.ts
+++ b/clients/js/src/generated/instructions/sellNftTokenPoolCore.ts
@@ -34,6 +34,7 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
+import { resolveEscrowProgramFromSharedEscrow } from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool } from '../../hooked';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -342,6 +343,12 @@ export async function getSellNftTokenPoolCoreInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -561,6 +568,9 @@ export function getSellNftTokenPoolCoreInstruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -568,6 +578,12 @@ export function getSellNftTokenPoolCoreInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTokenPoolT22.ts
+++ b/clients/js/src/generated/instructions/sellNftTokenPoolT22.ts
@@ -34,7 +34,10 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
-import { resolveOwnerAta } from '@tensor-foundation/resolvers';
+import {
+  resolveEscrowProgramFromSharedEscrow,
+  resolveOwnerAta,
+} from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool, resolveTakerAta } from '../../hooked';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -385,6 +388,12 @@ export async function getSellNftTokenPoolT22InstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -663,6 +672,9 @@ export function getSellNftTokenPoolT22Instruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -670,6 +682,12 @@ export function getSellNftTokenPoolT22Instruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTradePool.ts
+++ b/clients/js/src/generated/instructions/sellNftTradePool.ts
@@ -45,6 +45,7 @@ import {
   TokenStandard,
   resolveAuthorizationRulesProgramFromTokenStandard,
   resolveEditionFromTokenStandard,
+  resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolvePoolAta,
   resolvePoolTokenRecordFromTokenStandard,
@@ -546,6 +547,12 @@ export async function getSellNftTradePoolInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -973,6 +980,12 @@ export function getSellNftTradePoolInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTradePoolCore.ts
+++ b/clients/js/src/generated/instructions/sellNftTradePoolCore.ts
@@ -34,6 +34,7 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
+import { resolveEscrowProgramFromSharedEscrow } from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool } from '../../hooked';
 import { findAssetDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
@@ -368,6 +369,12 @@ export async function getSellNftTradePoolCoreInstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -615,6 +622,9 @@ export function getSellNftTradePoolCoreInstruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -622,6 +632,12 @@ export function getSellNftTradePoolCoreInstruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/clients/js/src/generated/instructions/sellNftTradePoolT22.ts
+++ b/clients/js/src/generated/instructions/sellNftTradePoolT22.ts
@@ -34,7 +34,10 @@ import {
   type WritableAccount,
   type WritableSignerAccount,
 } from '@solana/web3.js';
-import { resolvePoolAta } from '@tensor-foundation/resolvers';
+import {
+  resolveEscrowProgramFromSharedEscrow,
+  resolvePoolAta,
+} from '@tensor-foundation/resolvers';
 import { resolveFeeVaultPdaFromPool, resolveTakerAta } from '../../hooked';
 import { findNftDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
@@ -398,6 +401,12 @@ export async function getSellNftTradePoolT22InstructionAsync<
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
   }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
+  }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
@@ -691,6 +700,9 @@ export function getSellNftTradePoolT22Instruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.rentPayer.value) {
     accounts.rentPayer.value = expectSome(accounts.owner.value);
@@ -698,6 +710,12 @@ export function getSellNftTradePoolT22Instruction<
   if (!accounts.ammProgram.value) {
     accounts.ammProgram.value =
       'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg' as Address<'TAMM6ub33ij1mbetoMyVBLeKY5iP41i4UPUJQGkhfsg'>;
+  }
+  if (!accounts.escrowProgram.value) {
+    accounts.escrowProgram = {
+      ...accounts.escrowProgram,
+      ...resolveEscrowProgramFromSharedEscrow(resolverScope),
+    };
   }
   if (!accounts.nativeProgram.value) {
     accounts.nativeProgram.value =

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -244,6 +244,17 @@ kinobi.update(
         "systemProgram",
       ),
     },
+    {
+      account: "escrowProgram",
+      ignoreIfOptional: false,
+      defaultValue: k.resolverValueNode(
+        "resolveEscrowProgramFromSharedEscrow",
+        {
+          importFrom: "resolvers",
+          dependsOn: [k.accountValueNode("sharedEscrow")],
+        },
+      ),
+    },
     // pNFT specific accounts
     {
       account: "tokenMetadataProgram",


### PR DESCRIPTION
resolves escrowProgram acc if and only if `sharedEscrow` is given - this will make sure `escrowProgram` isn't needlessly specified as input account

depends on https://github.com/tensor-foundation/toolkit/pull/61, needs package.json in clients/js updated once that toolkit PR is merged