### PR TITLE
Fix/pre deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "amm-program"
-version = "0.8.1"
+version = "1.0.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "static_assertions",
  "tensor-escrow",
  "tensor-toolbox 0.8.0",
- "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tensor-vipers",
  "whitelist-program",
 ]
 
@@ -1013,7 +1013,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "tensor-toolbox 0.1.0",
- "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tensor-vipers",
 ]
 
 [[package]]
@@ -2614,12 +2614,14 @@ dependencies = [
  "spl-account-compression",
  "spl-noop",
  "spl-token-metadata-interface",
- "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tensor-vipers",
 ]
 
 [[package]]
 name = "tensor-toolbox"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515659dd8e1a324f23ced4d99d6a150ac8fac4d78c2cc0252b5dd5c39213192b"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2630,16 +2632,7 @@ dependencies = [
  "spl-account-compression",
  "spl-noop",
  "spl-token-metadata-interface",
- "tensor-vipers 1.0.1",
-]
-
-[[package]]
-name = "tensor-vipers"
-version = "1.0.1"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "num-traits",
+ "tensor-vipers",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "spl-token-metadata-interface",
  "static_assertions",
  "tensor-escrow",
- "tensor-toolbox 0.7.1",
+ "tensor-toolbox 0.8.0",
  "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "whitelist-program",
 ]
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "tensor-toolbox"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,8 +85,8 @@ dependencies = [
  "spl-token-metadata-interface",
  "static_assertions",
  "tensor-escrow",
- "tensor-toolbox 0.6.0",
- "tensor-vipers",
+ "tensor-toolbox 0.7.1",
+ "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "whitelist-program",
 ]
 
@@ -1013,7 +1013,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "tensor-toolbox 0.1.0",
- "tensor-vipers",
+ "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2614,14 +2614,12 @@ dependencies = [
  "spl-account-compression",
  "spl-noop",
  "spl-token-metadata-interface",
- "tensor-vipers",
+ "tensor-vipers 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tensor-toolbox"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9cad383562b37eae13c0b7444782c3d6e02e5529707480a4a68769ba4849a1"
+version = "0.7.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -2632,7 +2630,16 @@ dependencies = [
  "spl-account-compression",
  "spl-noop",
  "spl-token-metadata-interface",
- "tensor-vipers",
+ "tensor-vipers 1.0.1",
+]
+
+[[package]]
+name = "tensor-vipers"
+version = "1.0.1"
+dependencies = [
+ "anchor-lang",
+ "anchor-spl",
+ "num-traits",
 ]
 
 [[package]]

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/amm",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "description": "Version 2 of the Tensor AMM program.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/clients/js/src/generated/errors/tensorAmm.ts
+++ b/clients/js/src/generated/errors/tensorAmm.ts
@@ -70,6 +70,8 @@ export const TENSOR_AMM_ERROR__ESCROW_PROGRAM_NOT_SET = 0x2ef9; // 12025
 export const TENSOR_AMM_ERROR__MISSING_MAKER_BROKER = 0x2efa; // 12026
 /** MissingCosigner: Missing cosigner account */
 export const TENSOR_AMM_ERROR__MISSING_COSIGNER = 0x2efb; // 12027
+/** InvalidEdition: Invalid edition */
+export const TENSOR_AMM_ERROR__INVALID_EDITION = 0x2efc; // 12028
 
 export type TensorAmmError =
   | typeof TENSOR_AMM_ERROR__ARITHMETIC_ERROR
@@ -83,6 +85,7 @@ export type TensorAmmError =
   | typeof TENSOR_AMM_ERROR__EXPIRY_TOO_LARGE
   | typeof TENSOR_AMM_ERROR__FEES_NOT_ALLOWED
   | typeof TENSOR_AMM_ERROR__FEES_TOO_HIGH
+  | typeof TENSOR_AMM_ERROR__INVALID_EDITION
   | typeof TENSOR_AMM_ERROR__INVALID_POOL_AMOUNT
   | typeof TENSOR_AMM_ERROR__MAX_TAKER_SELL_COUNT_EXCEEDED
   | typeof TENSOR_AMM_ERROR__MAX_TAKER_SELL_COUNT_TOO_SMALL
@@ -115,6 +118,7 @@ if (process.env.NODE_ENV !== 'production') {
     [TENSOR_AMM_ERROR__EXPIRY_TOO_LARGE]: `Expiry too large`,
     [TENSOR_AMM_ERROR__FEES_NOT_ALLOWED]: `fees not allowed for non-trade pools`,
     [TENSOR_AMM_ERROR__FEES_TOO_HIGH]: `fees entered above allowed threshold`,
+    [TENSOR_AMM_ERROR__INVALID_EDITION]: `Invalid edition`,
     [TENSOR_AMM_ERROR__INVALID_POOL_AMOUNT]: `Invalid pool amount`,
     [TENSOR_AMM_ERROR__MAX_TAKER_SELL_COUNT_EXCEEDED]: `max taker sell count exceeded, pool cannot buy anymore NFTs`,
     [TENSOR_AMM_ERROR__MAX_TAKER_SELL_COUNT_TOO_SMALL]: `max taker sell count is too small`,

--- a/clients/js/src/generated/instructions/buyNft.ts
+++ b/clients/js/src/generated/instructions/buyNft.ts
@@ -47,7 +47,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolvePoolAta,
@@ -56,6 +55,7 @@ import {
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
 import {
+  resolveEdition,
   resolveFeeVaultPdaFromPool,
   resolveTakerAta,
   resolveUserTokenRecordFromTokenStandard,
@@ -576,7 +576,7 @@ export async function getBuyNftInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.tokenProgram.value) {

--- a/clients/js/src/generated/instructions/depositNft.ts
+++ b/clients/js/src/generated/instructions/depositNft.ts
@@ -41,7 +41,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveMetadata,
   resolveOwnerAta,
   resolvePoolAta,
@@ -49,7 +48,10 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
-import { resolveUserTokenRecordFromTokenStandard } from '../../hooked';
+import {
+  resolveEdition,
+  resolveUserTokenRecordFromTokenStandard,
+} from '../../hooked';
 import { findNftDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -413,7 +415,7 @@ export async function getDepositNftInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.tokenProgram.value) {

--- a/clients/js/src/generated/instructions/sellNftTokenPool.ts
+++ b/clients/js/src/generated/instructions/sellNftTokenPool.ts
@@ -47,7 +47,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolveOwnerAta,
@@ -58,6 +57,7 @@ import {
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
 import {
+  resolveEdition,
   resolveFeeVaultPdaFromPool,
   resolveTakerAta,
   resolveUserTokenRecordFromTokenStandard,
@@ -594,7 +594,7 @@ export async function getSellNftTokenPoolInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.tokenProgram.value) {

--- a/clients/js/src/generated/instructions/sellNftTradePool.ts
+++ b/clients/js/src/generated/instructions/sellNftTradePool.ts
@@ -47,7 +47,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveEscrowProgramFromSharedEscrow,
   resolveMetadata,
   resolvePoolAta,
@@ -56,6 +55,7 @@ import {
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
 import {
+  resolveEdition,
   resolveFeeVaultPdaFromPool,
   resolveTakerAta,
   resolveUserTokenRecordFromTokenStandard,
@@ -580,7 +580,7 @@ export async function getSellNftTradePoolInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.tokenProgram.value) {

--- a/clients/js/src/generated/instructions/withdrawNft.ts
+++ b/clients/js/src/generated/instructions/withdrawNft.ts
@@ -41,7 +41,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveMetadata,
   resolveOwnerAta,
   resolvePoolAta,
@@ -49,7 +48,10 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
-import { resolveUserTokenRecordFromTokenStandard } from '../../hooked';
+import {
+  resolveEdition,
+  resolveUserTokenRecordFromTokenStandard,
+} from '../../hooked';
 import { findNftDepositReceiptPda } from '../pdas';
 import { TENSOR_AMM_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -415,7 +417,7 @@ export async function getWithdrawNftInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.tokenProgram.value) {

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -1,14 +1,15 @@
 import { address, ProgramDerivedAddress } from '@solana/web3.js';
 import {
-  findAssociatedTokenAccountPda,
-  findFeeVaultPda,
-  findNftReceiptPda,
-} from '@tensor-foundation/resolvers';
-import { ResolvedAccount, expectAddress } from '../generated/shared';
-import {
   findTokenRecordPda,
   TokenStandard,
 } from '@tensor-foundation/mpl-token-metadata';
+import {
+  findAssociatedTokenAccountPda,
+  findEditionPda,
+  findFeeVaultPda,
+  findNftReceiptPda,
+} from '@tensor-foundation/resolvers';
+import { expectAddress, ResolvedAccount } from '../generated/shared';
 
 // Satisfy linter
 type ArgsAny = {
@@ -97,4 +98,16 @@ export const resolveUserTokenRecordFromTokenStandard = async ({
         }),
       }
     : { value: null };
+};
+
+export const resolveEdition = async ({
+  accounts,
+}: {
+  accounts: Record<string, ResolvedAccount>;
+}): Promise<Partial<{ value: ProgramDerivedAddress | null }>> => {
+  return {
+    value: await findEditionPda({
+      mint: expectAddress(accounts.mint?.value),
+    }),
+  };
 };

--- a/clients/js/test/legacy/sell.test.ts
+++ b/clients/js/test/legacy/sell.test.ts
@@ -1018,7 +1018,7 @@ test('sell into shared escrow pool cannot eat into escrow account rent', async (
     action: TestAction.Sell,
     useMakerBroker: false,
     useSharedEscrow: true,
-    fundPool: true,
+    fundPool: false,
     depositAmount,
     whitelistMode: Mode.FVC,
   });

--- a/clients/js/test/legacy/sell.test.ts
+++ b/clients/js/test/legacy/sell.test.ts
@@ -164,6 +164,48 @@ test('sell NFT into Trade pool, wrong owner fails', async (t) => {
   });
 });
 
+test('sell NFT into Trade pool, wrong edition fails', async (t) => {
+  const { client, signers, nft, testConfig, pool, whitelist } =
+    await setupLegacyTest({
+      t,
+      poolType: PoolType.Trade,
+      action: TestAction.Sell,
+      useMakerBroker: false,
+      useSharedEscrow: false,
+      useCosigner: false,
+      fundPool: true,
+    });
+
+  const { poolOwner, nftOwner, nftUpdateAuthority } = signers;
+  const { mint } = nft;
+  const { price: minPrice } = testConfig;
+
+  const wrongEdition = await generateKeyPairSigner();
+
+  // Sell NFT into pool
+  const sellNftIx = await getSellNftTradePoolInstructionAsync({
+    owner: poolOwner.address, // pool owner
+    taker: nftOwner, // nft owner--the seller
+    pool,
+    whitelist,
+    mint,
+    minPrice,
+    edition: wrongEdition.address,
+    // Remaining accounts
+    creators: [nftUpdateAuthority.address],
+    escrowProgram: TSWAP_PROGRAM_ID,
+  });
+
+  const promise = pipe(
+    await createDefaultTransaction(client, nftOwner),
+    (tx) => appendTransactionMessageInstruction(sellNftIx, tx),
+    (tx) => signAndSendTransaction(client, tx)
+  );
+
+  // Edition fails on Anchor seeds check.
+  await expectCustomError(t, promise, ANCHOR_ERROR__CONSTRAINT_SEEDS);
+});
+
 test('sell NFT into NFT pool fails', async (t) => {
   // Setup a NFT pool, with a NFT deposited.
   const legacyTest = await setupLegacyTest({

--- a/clients/js/test/mpl_core/_common.ts
+++ b/clients/js/test/mpl_core/_common.ts
@@ -167,7 +167,12 @@ export async function setupCoreTest(
 
   if (useSharedEscrow) {
     // Create a shared escrow account.
-    sharedEscrow = await createAndFundEscrow(client, poolOwner, 1);
+    sharedEscrow = await createAndFundEscrow(
+      client,
+      poolOwner,
+      1,
+      depositAmount
+    );
   }
 
   let conditions: Condition[] = [];

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "tensor-amm"
-version = "0.8.0"
+version = "1.0.0"
 dependencies = [
  "anchor-lang",
  "assert_matches",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensor-amm"
-version = "0.8.0"
+version = "1.0.0"
 description = "Client crate for the Tensor Foundation amm program."
 repository = "https://github.com/tensor-foundation/amm"
 homepage = "https://github.com/tensor-foundation/amm"

--- a/clients/rust/src/generated/errors/tensor_amm.rs
+++ b/clients/rust/src/generated/errors/tensor_amm.rs
@@ -94,6 +94,9 @@ pub enum TensorAmmError {
     /// 12027 - Missing cosigner account
     #[error("Missing cosigner account")]
     MissingCosigner = 0x2EFB,
+    /// 12028 - Invalid edition
+    #[error("Invalid edition")]
+    InvalidEdition = 0x2EFC,
 }
 
 impl solana_program::program_error::PrintProgramError for TensorAmmError {

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amm-program"
-version = "0.8.1"
+version = "1.0.0"
 edition = "2021"
 readme = "./README.md"
 license-file = "../LICENSE"

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -57,11 +57,7 @@ spl-math = { version = "0.1.0", features = ["no-entrypoint"] }
 spl-token-metadata-interface = "0.2.0"
 static_assertions = "1.1.0"
 tensor-escrow = { version = "0.1.1" }
-# tensor-toolbox = { version = "0.9.0", features = ["token-2022", "mpl-core"] }
-tensor-toolbox = { path = "../../toolbox/toolbox", features = [
-    "token-2022",
-    "mpl-core",
-] }
+tensor-toolbox = { version = "0.8.0", features = ["token-2022", "mpl-core"] }
 tensor-vipers = { version = "1.0.1" }
 whitelist-program = { package = "whitelist-program", git = "ssh://git@github.com/tensor-foundation/whitelist.git", rev = "346eac4", features = [
     "cpi",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -57,7 +57,11 @@ spl-math = { version = "0.1.0", features = ["no-entrypoint"] }
 spl-token-metadata-interface = "0.2.0"
 static_assertions = "1.1.0"
 tensor-escrow = { version = "0.1.1" }
-tensor-toolbox = { version = "0.6.0", features = ["token-2022", "mpl-core"] }
+# tensor-toolbox = { version = "0.9.0", features = ["token-2022", "mpl-core"] }
+tensor-toolbox = { path = "../../toolbox/toolbox", features = [
+    "token-2022",
+    "mpl-core",
+] }
 tensor-vipers = { version = "1.0.1" }
 whitelist-program = { package = "whitelist-program", git = "ssh://git@github.com/tensor-foundation/whitelist.git", rev = "346eac4", features = [
     "cpi",

--- a/program/idl.json
+++ b/program/idl.json
@@ -3903,6 +3903,11 @@
       "code": 12027,
       "name": "MissingCosigner",
       "msg": "Missing cosigner account"
+    },
+    {
+      "code": 12028,
+      "name": "InvalidEdition",
+      "msg": "Invalid edition"
     }
   ],
   "metadata": {

--- a/program/idl.json
+++ b/program/idl.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.1",
+  "version": "1.0.0",
   "name": "amm_program",
   "docs": [
     "Program entrypoint"

--- a/program/idl.json
+++ b/program/idl.json
@@ -1552,7 +1552,7 @@
     {
       "name": "depositNftCore",
       "docs": [
-        "Deposit a Token22 NFT into a NFT or Trade pool."
+        "Deposit a MPL Core asset into a NFT or Trade pool."
       ],
       "accounts": [
         {
@@ -1645,7 +1645,7 @@
     {
       "name": "withdrawNftCore",
       "docs": [
-        "Withdraw a Token22 NFT from a NFT or Trade pool."
+        "Withdraw a MPL Core asset from a NFT or Trade pool."
       ],
       "accounts": [
         {
@@ -1730,7 +1730,7 @@
     {
       "name": "buyNftCore",
       "docs": [
-        "Buy a Token22 NFT from a NFT or Trade pool."
+        "Buy a MPL Core asset from a NFT or Trade pool."
       ],
       "accounts": [
         {
@@ -1913,7 +1913,7 @@
     {
       "name": "sellNftTokenPoolCore",
       "docs": [
-        "Sell a Token22 NFT into a Token pool."
+        "Sell a MPL Core asset into a Token pool."
       ],
       "accounts": [
         {
@@ -2080,7 +2080,7 @@
     {
       "name": "sellNftTradePoolCore",
       "docs": [
-        "Sell a Token22 NFT into a Trade pool."
+        "Sell a MPL Core asset into a Trade pool."
       ],
       "accounts": [
         {

--- a/program/src/constants.rs
+++ b/program/src/constants.rs
@@ -10,10 +10,11 @@ pub const CURRENT_POOL_VERSION: u8 = 1;
 
 /// Maximum allowed MM fees in basis points.
 #[constant]
-pub const MAX_MM_FEES_BPS: u16 = 7500; //75%
+pub const MAX_MM_FEES_BPS: u16 = 7500; // 75%
+
 /// Maximum delta in basis points for a trade pool.
 #[constant]
-pub const MAX_DELTA_BPS: u16 = 9999; //99%
+pub const MAX_DELTA_BPS: u16 = 9999; // 99.99%
 
 /// The pubkey of the Tensor Foundation Fees program.
 pub(crate) const TFEE_PROGRAM_ID: Pubkey = pubkey!("TFEEgwDP6nn1s8mMX2tTNPPz8j2VomkphLUmyxKm17A");

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -87,4 +87,7 @@ pub enum ErrorCode {
 
     #[msg("Missing cosigner account")]
     MissingCosigner,
+
+    #[msg("Invalid edition")]
+    InvalidEdition,
 }

--- a/program/src/instructions/legacy/buy_nft.rs
+++ b/program/src/instructions/legacy/buy_nft.rs
@@ -157,5 +157,11 @@ pub fn process_buy_nft<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         owner,
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/instructions/legacy/sell_nft_token_pool.rs
+++ b/program/src/instructions/legacy/sell_nft_token_pool.rs
@@ -201,5 +201,11 @@ pub fn process_sell_nft_token_pool<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         owner,
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/instructions/mplx_core/buy_nft.rs
+++ b/program/src/instructions/mplx_core/buy_nft.rs
@@ -93,5 +93,11 @@ pub fn process_buy_nft_core<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         owner,
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/instructions/mplx_core/sell_nft_token_pool.rs
+++ b/program/src/instructions/mplx_core/sell_nft_token_pool.rs
@@ -68,5 +68,11 @@ pub fn process_sell_nft_token_pool_core<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         ctx.accounts.trade.owner.to_account_info(),
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/instructions/mplx_core/withdraw_nft.rs
+++ b/program/src/instructions/mplx_core/withdraw_nft.rs
@@ -31,7 +31,7 @@ impl<'info> WithdrawNftCore<'info> {
     }
 }
 
-/// Withdraw a Token22 NFT from a NFT or Trade pool.
+/// Withdraw a MPL Core Asset from a NFT or Trade pool.
 pub fn process_withdraw_nft_core<'info>(
     ctx: Context<'_, '_, '_, 'info, WithdrawNftCore<'info>>,
 ) -> Result<()> {

--- a/program/src/instructions/shared_accounts.rs
+++ b/program/src/instructions/shared_accounts.rs
@@ -655,15 +655,12 @@ impl<'info> ValidateAsset<'info> for MplxShared<'info> {
 
         // Verify edition is valid, this should be a Master Edition or Edition.
         let key = self.edition.try_borrow_data()?[0];
-        msg!("key: {}", key);
 
         match key {
             k if k == MplKey::MasterEditionV1 as u8 || k == MplKey::MasterEditionV2 as u8 => {
-                msg!("master edition");
                 assert_decode_master_edition(&self.edition)?;
             }
             k if k == MplKey::EditionV1 as u8 => {
-                msg!("edition");
                 assert_decode_edition(&self.edition)?;
             }
             _ => return Err(ErrorCode::InvalidEdition.into()),

--- a/program/src/instructions/t22/buy_nft.rs
+++ b/program/src/instructions/t22/buy_nft.rs
@@ -133,5 +133,11 @@ pub fn process_buy_nft_t22<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         ctx.accounts.trade.owner.to_account_info(),
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/instructions/t22/sell_nft_token_pool.rs
+++ b/program/src/instructions/t22/sell_nft_token_pool.rs
@@ -108,5 +108,11 @@ pub fn process_sell_nft_token_pool_t22<'info>(
         &ctx.accounts.trade.pool,
         ctx.accounts.trade.rent_payer.to_account_info(),
         ctx.accounts.trade.owner.to_account_info(),
+        ctx.accounts
+            .trade
+            .shared_escrow
+            .as_ref()
+            .map(|escrow| escrow.to_account_info())
+            .as_ref(),
     )
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -134,21 +134,21 @@ pub mod amm_program {
     // MPL Core instructions         //
     //-------------------------------//
 
-    /// Deposit a Token22 NFT into a NFT or Trade pool.
+    /// Deposit a MPL Core asset into a NFT or Trade pool.
     pub fn deposit_nft_core<'info>(
         ctx: Context<'_, '_, '_, 'info, DepositNftCore<'info>>,
     ) -> Result<()> {
         instructions::mplx_core::process_deposit_nft_core(ctx)
     }
 
-    /// Withdraw a Token22 NFT from a NFT or Trade pool.
+    /// Withdraw a MPL Core asset from a NFT or Trade pool.
     pub fn withdraw_nft_core<'info>(
         ctx: Context<'_, '_, '_, 'info, WithdrawNftCore<'info>>,
     ) -> Result<()> {
         instructions::mplx_core::process_withdraw_nft_core(ctx)
     }
 
-    /// Buy a Token22 NFT from a NFT or Trade pool.
+    /// Buy a MPL Core asset from a NFT or Trade pool.
     pub fn buy_nft_core<'info>(
         ctx: Context<'_, '_, '_, 'info, BuyNftCore<'info>>,
         max_amount: u64,
@@ -156,7 +156,7 @@ pub mod amm_program {
         instructions::mplx_core::process_buy_nft_core(ctx, max_amount)
     }
 
-    /// Sell a Token22 NFT into a Token pool.
+    /// Sell a MPL Core asset into a Token pool.
     pub fn sell_nft_token_pool_core<'info>(
         ctx: Context<'_, '_, '_, 'info, SellNftTokenPoolCore<'info>>,
         min_price: u64,
@@ -166,7 +166,7 @@ pub mod amm_program {
         )
     }
 
-    /// Sell a Token22 NFT into a Trade pool.
+    /// Sell a MPL Core asset into a Trade pool.
     pub fn sell_nft_trade_pool_core<'info>(
         ctx: Context<'_, '_, '_, 'info, SellNftTradePoolCore<'info>>,
         min_price: u64,

--- a/program/src/state/pool.rs
+++ b/program/src/state/pool.rs
@@ -192,7 +192,7 @@ impl Pool {
             return Ok(());
         }
 
-        //if the pool has made more sells than buys, by defn it can buy more to get to initial state
+        //if the pool has made more buys than sells, by definition it can sell more to get to initial state.
         if self.stats.taker_buy_count > self.stats.taker_sell_count {
             return Ok(());
         }

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -440,7 +440,7 @@ codama.update(
     {
       account: "edition",
       ignoreIfOptional: true,
-      defaultValue: c.resolverValueNode("resolveEditionFromTokenStandard", {
+      defaultValue: c.resolverValueNode("resolveEdition", {
         dependsOn: [c.accountValueNode("mint")]
       })
     },
@@ -503,30 +503,38 @@ codama.accept(
     },
     linkOverrides: {
       resolvers: {
-        resolveSourceAta: '@tensor-foundation/resolvers',
-        resolveDestinationAta: '@tensor-foundation/resolvers',
-        resolveOwnerAta: '@tensor-foundation/resolvers', 
-        resolveBuyerAta: '@tensor-foundation/resolvers',
-        resolveSellerAta: '@tensor-foundation/resolvers',
-        resolvePoolAta: '@tensor-foundation/resolvers',
-        resolveSourceTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveDestinationTokenRecordFromTokenStandard: '@tensor-foundation/resolvers', 
-        resolveOwnerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveBuyerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveSellerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolvePoolTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveMetadata: '@tensor-foundation/resolvers',
-        resolveEditionFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveAuthorizationRulesProgramFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveTokenMetadataProgramFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveSysvarInstructionsFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveEscrowProgramFromSharedEscrow: '@tensor-foundation/resolvers'
+        resolveSourceAta: "@tensor-foundation/resolvers",
+        resolveDestinationAta: "@tensor-foundation/resolvers",
+        resolveOwnerAta: "@tensor-foundation/resolvers",
+        resolveBuyerAta: "@tensor-foundation/resolvers",
+        resolveSellerAta: "@tensor-foundation/resolvers",
+        resolvePoolAta: "@tensor-foundation/resolvers",
+        resolveSourceTokenRecordFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveDestinationTokenRecordFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveOwnerTokenRecordFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveBuyerTokenRecordFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveSellerTokenRecordFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolvePoolTokenRecordFromTokenStandard: "@tensor-foundation/resolvers",
+        resolveMetadata: "@tensor-foundation/resolvers",
+        resolveEditionFromTokenStandard: "@tensor-foundation/resolvers",
+        resolveAuthorizationRulesProgramFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveTokenMetadataProgramFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveSysvarInstructionsFromTokenStandard:
+          "@tensor-foundation/resolvers",
+        resolveEscrowProgramFromSharedEscrow: "@tensor-foundation/resolvers"
       },
       definedTypes: {
-        tokenStandard: '@tensor-foundation/mpl-token-metadata',
-        nullableAddress: '../../hooked',
-        currency: '../../hooked',
-        nullableU16: '../../hooked'
+        tokenStandard: "@tensor-foundation/mpl-token-metadata",
+        nullableAddress: "../../hooked",
+        currency: "../../hooked",
+        nullableU16: "../../hooked"
       }
     },
     asyncResolvers: [
@@ -547,7 +555,8 @@ codama.accept(
       "resolvePoolTokenRecordFromTokenStandard",
       "resolvePoolNftReceipt",
       "resolveMetadata",
-      "resolveEditionFromTokenStandard"
+      "resolveEditionFromTokenStandard",
+      "resolveEdition"
     ]
   })
 );
@@ -560,9 +569,9 @@ codama.accept(
     crateFolder: rustClient,
     linkOverrides: {
       definedTypes: {
-        nullableAddress: 'crate::hooked',
-        currency: 'crate::hooked',
-        nullableU16: 'crate::hooked'
+        nullableAddress: "crate::hooked",
+        currency: "crate::hooked",
+        nullableU16: "crate::hooked"
       }
     }
   })


### PR DESCRIPTION
* Fixes some comments
* Adds seeds checks for Metadata and Edition accounts to `MplxShared`
* Validates edition in addition to metadata in legacy `validate_asset` impl
* When attempting to autoclose pools, checks shared_escrow amount for pools with that field set, instead of pool lamports