### PR TITLE
was so focussed on edge cases, that I didnt check the base case lol

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/amm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Version 2 of the Tensor AMM program.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/clients/js/src/hooked/helpers.ts
+++ b/clients/js/src/hooked/helpers.ts
@@ -147,8 +147,8 @@ export function getAmountOfBids({
     let bidCount = 0;
     let accumulatedPrice = 0n;
     while (
-      accumulatedPrice < BigInt(availableLamports) &&
-      bidCount < maxPossibleBidsBeforeZero + 1
+      accumulatedPrice <= BigInt(availableLamports) &&
+      bidCount <= maxPossibleBidsBeforeZero
     ) {
       const price = calculatePrice({
         pool,
@@ -172,8 +172,8 @@ export function getAmountOfBids({
     let bidCount = 0;
     let accumulatedPrice = 0n;
     while (
-      accumulatedPrice < BigInt(availableLamports) &&
-      bidCount < BID_AMOUNT_LIMIT + 1
+      accumulatedPrice <= BigInt(availableLamports) &&
+      bidCount <= BID_AMOUNT_LIMIT
     ) {
       const price = calculatePrice({
         pool,

--- a/clients/js/src/hooked/helpers.ts
+++ b/clients/js/src/hooked/helpers.ts
@@ -120,7 +120,7 @@ export function getAmountOfBids({
   availableLamports: number | bigint;
 }): number {
   if (pool.config.poolType === PoolType.NFT) return 0;
-  if (pool.config.startingPrice === 0n) return 0;
+  if (pool.config.startingPrice <= 0n) return 0;
 
   let amountOfBidsWithoutMaxCount: number;
   // Trade pool that compounds fees ==> include mm fee (goes back into available balance)

--- a/clients/js/src/hooked/helpers.ts
+++ b/clients/js/src/hooked/helpers.ts
@@ -120,6 +120,7 @@ export function getAmountOfBids({
   availableLamports: number | bigint;
 }): number {
   if (pool.config.poolType === PoolType.NFT) return 0;
+  if (pool.config.startingPrice === 0n) return 0;
 
   let amountOfBidsWithoutMaxCount: number;
   // Trade pool that compounds fees ==> include mm fee (goes back into available balance)
@@ -135,7 +136,7 @@ export function getAmountOfBids({
       extraOffset: 0,
       excludeMMFee,
     });
-    if (currentPrice < 0) return 0;
+    if (currentPrice <= 0) return 0;
     let maxPossibleBidsBeforeZero =
       pool.config.delta <= 0n
         ? BID_AMOUNT_LIMIT

--- a/clients/js/test/pricingHelpers.test.ts
+++ b/clients/js/test/pricingHelpers.test.ts
@@ -595,6 +595,38 @@ test('getAmountOfBids returns a max of 1000 bids for "indefinite" amounts', asyn
   t.true(amountOfBids === 1000);
 });
 
+test('getAmountOfBids base case exponential', (t) => {
+  const config: PoolConfig = {
+    poolType: PoolType.Token,
+    curveType: CurveType.Exponential,
+    startingPrice: 1n * ONE_SOL,
+    delta: 0n,
+    mmCompoundFees: false,
+    mmFeeBps: 0,
+  };
+  const amountOfBids = getAmountOfBids({
+    pool: { config, priceOffset: 0, maxTakerSellCount: 0, sharedEscrow: null },
+    availableLamports: 1n * ONE_SOL,
+  });
+  t.true(amountOfBids === 1);
+});
+
+test('getAmountOfBids base case linear', (t) => {
+  const config: PoolConfig = {
+    poolType: PoolType.Token,
+    curveType: CurveType.Linear,
+    startingPrice: 1n * ONE_SOL,
+    delta: 0n,
+    mmCompoundFees: false,
+    mmFeeBps: null,
+  };
+  const amountOfBids = getAmountOfBids({
+    pool: { config, priceOffset: 0, maxTakerSellCount: 0, sharedEscrow: null },
+    availableLamports: 1n * ONE_SOL,
+  });
+  t.true(amountOfBids === 1);
+});
+
 test('getAmountOfBids returns correct values for exponential pools', async (t) => {
   const config: PoolConfig = {
     poolType: PoolType.Trade,


### PR DESCRIPTION
- fixes `getAmountOfBids` if available lamports exactly match the lamports needed for x bids (e.g. 1 sol avail lamports, starting price 1 sol, 0 delta, 0 mmFeeBps) 
- adds regression test for the above 