### PR TITLE
pricing helpers: arg type checks, throw helpful errors

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/amm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Version 2 of the Tensor AMM program.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",


### PR DESCRIPTION
prev: when a user would disable type checks, pricing helpers could return incorrect prices because of simple if-else for binary types like `CurveType`

- this adds stricter type checks to avoid any unexpected / incorrect returns for bad arg input types 