### PR TITLE
fix available bids maxTaker logic

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/amm",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Version 2 of the Tensor AMM program.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",


### PR DESCRIPTION
issue: while in 99% of cases `pool.poolOffset == pool.stats.takerSellCount - pool.stats.takerBuyCount`, this doesn't apply when the pool gets edited with `resetPriceOffset = true` ==> in this case, `poolOffset` is needed for price calculation, but `pool.stats.takerSellCount - pool.stats.takerBuyCount` is needed for comparing against `pool.maxTakerSellCount`

- fixes maxTakerSellCount related helper functions to use `pool.stats.takerSellCount - pool.stats.takerBuyCount` instead of `pool.poolOffset` to compare against `pool.maxTakerSellCount`